### PR TITLE
Fixes to goToHour and goToDate().

### DIFF
--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -94,12 +94,15 @@ public class WeekView extends View {
     private int mHeaderColumnBackgroundColor = Color.WHITE;
     private int mDefaultEventColor;
     private boolean mIsFirstDraw = true;
+    private boolean mAreDimensionsInvalid = true;
     @Deprecated private int mDayNameLength = LENGTH_LONG;
     private int mOverlappingEventGap = 0;
     private int mEventMarginVertical = 0;
     private float mXScrollingSpeed = 1f;
     private Calendar mFirstVisibleDay;
     private Calendar mLastVisibleDay;
+    private Calendar mScrollToDay = null;
+    private double mScrollToHour = -1;
 
     // Listeners.
     private EventClickListener mEventClickListener;
@@ -378,13 +381,23 @@ public class WeekView extends View {
         mWidthPerDay = getWidth() - mHeaderColumnWidth - mColumnGap * (mNumberOfVisibleDays - 1);
         mWidthPerDay = mWidthPerDay/mNumberOfVisibleDays;
 
-        // If the week view is being drawn for the first time, then consider the first day of week.
-        if (mIsFirstDraw && mNumberOfVisibleDays >= 7) {
-            if (mToday.get(Calendar.DAY_OF_WEEK) != mFirstDayOfWeek) {
+        if (mAreDimensionsInvalid) {
+            mAreDimensionsInvalid = false;
+            double scrollToHour = mScrollToHour;
+
+            if(mScrollToDay != null)
+                goToDate(mScrollToDay);
+            if(scrollToHour >= 0)
+                goToHour(scrollToHour);
+        }
+        if (mIsFirstDraw){
+            mIsFirstDraw = false;
+
+            // If the week view is being drawn for the first time, then consider the first day of the week.
+            if(mNumberOfVisibleDays >= 7 && mToday.get(Calendar.DAY_OF_WEEK) != mFirstDayOfWeek) {
                 int difference = 7 + (mToday.get(Calendar.DAY_OF_WEEK) - mFirstDayOfWeek);
                 mCurrentOrigin.x += (mWidthPerDay + mColumnGap) * difference;
             }
-            mIsFirstDraw = false;
         }
 
         // Consider scroll offset.
@@ -904,6 +917,13 @@ public class WeekView extends View {
         mEventRects.addAll(newEvents);
     }
 
+    @Override
+    public void invalidate() {
+        super.invalidate();
+        mAreDimensionsInvalid = true;
+        mScrollToDay = null;
+        mScrollToHour = -1;
+    }
 
     /////////////////////////////////////////////////////////////////
     //
@@ -1351,6 +1371,11 @@ public class WeekView extends View {
         date.set(Calendar.SECOND, 0);
         date.set(Calendar.MILLISECOND, 0);
 
+        if(mAreDimensionsInvalid) {
+            mScrollToDay = date;
+            return;
+        }
+
         mRefreshEvents = true;
 
         Calendar today = Calendar.getInstance();
@@ -1360,8 +1385,7 @@ public class WeekView extends View {
         today.set(Calendar.MILLISECOND, 0);
 
         int dateDifference = (int) ((date.getTimeInMillis() - today.getTimeInMillis()) / (1000 * 60 * 60 * 24));
-        mCurrentOrigin.x = - dateDifference * (mWidthPerDay + mColumnGap);
-
+        mStickyScroller.startScroll((int) mCurrentOrigin.x, 0, (int) (-dateDifference*(mWidthPerDay + mColumnGap)-mCurrentOrigin.x), 0);
         invalidate();
     }
 
@@ -1378,14 +1402,18 @@ public class WeekView extends View {
      * @param hour The hour to scroll to in 24-hour format. Supported values are 0-24.
      */
     public void goToHour(double hour){
-        if (hour < 0)
-            throw new IllegalArgumentException("Cannot scroll to an hour of negative value.");
-        else if (hour > 24)
-            throw new IllegalArgumentException("Cannot scroll to an hour of value greater than 24.");
-        else if (hour * mHourHeight > mHourHeight * 24 - getHeight() + mHeaderTextHeight + mHeaderRowPadding * 2 + mHeaderMarginBottom)
-            throw new IllegalArgumentException("Cannot scroll to an hour which will result the calendar to go off the screen.");
-
         int verticalOffset = (int) (mHourHeight * hour);
+        if (hour < 0)
+            verticalOffset = 0;
+        else if (hour > 24)
+            verticalOffset = mHourHeight * 24;
+
+        if (mAreDimensionsInvalid) {
+            mScrollToHour = hour;
+            return;
+        } else if (verticalOffset > mHourHeight * 24 - getHeight() + mHeaderTextHeight + mHeaderRowPadding * 2 + mHeaderMarginBottom)
+            verticalOffset = (int)(mHourHeight * 24 - getHeight() + mHeaderTextHeight + mHeaderRowPadding * 2 + mHeaderMarginBottom);
+
         mCurrentOrigin.y = -verticalOffset;
         invalidate();
     }

--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -383,12 +383,16 @@ public class WeekView extends View {
 
         if (mAreDimensionsInvalid) {
             mAreDimensionsInvalid = false;
-            double scrollToHour = mScrollToHour;
-
             if(mScrollToDay != null)
                 goToDate(mScrollToDay);
-            if(scrollToHour >= 0)
-                goToHour(scrollToHour);
+
+            mAreDimensionsInvalid = false;
+            if(mScrollToHour >= 0)
+                goToHour(mScrollToHour);
+
+            mScrollToDay = null;
+            mScrollToHour = -1;
+            mAreDimensionsInvalid = false;
         }
         if (mIsFirstDraw){
             mIsFirstDraw = false;
@@ -921,8 +925,6 @@ public class WeekView extends View {
     public void invalidate() {
         super.invalidate();
         mAreDimensionsInvalid = true;
-        mScrollToDay = null;
-        mScrollToHour = -1;
     }
 
     /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Allow goToDate to be called before the weekview is drawn for the first time.

goToDate relies on mWidthPerDay, which itself relies on View#getWidth() which can't be called during initialisation. Therefore the goToDate variable is cached until the first time the weekview is drawn.

Fixes #45:
1. Date is cloned before use (in goToDate)
2. goToHour doesn't throw errors anymore

Fixes #55:
goToDate now uses an animation

Fixes #65:
If a dimension is altered and is followed by a goToDate or goToHour, then the hour or date to go to, is cached.