### PR TITLE
Solved a collision bug

### DIFF
--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -640,6 +640,28 @@ public class WeekView extends View {
         public float top;
         public float bottom;
 
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            EventRect eventRect = (EventRect) o;
+
+            if (event != null ? !event.equals(eventRect.event) : eventRect.event != null)
+                return false;
+            if (originalEvent != null ? !originalEvent.equals(eventRect.originalEvent) : eventRect.originalEvent != null)
+                return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = event != null ? event.hashCode() : 0;
+            result = 31 * result + (originalEvent != null ? originalEvent.hashCode() : 0);
+            return result;
+        }
+
         /**
          * Create a new instance of event rect. An EventRect is actually the rectangle that is drawn
          * on the calendar for a given event. There may be more than one rectangle for a single
@@ -735,8 +757,11 @@ public class WeekView extends View {
         while (dayCounter.getTimeInMillis() <= maxDay.getTimeInMillis()) {
             ArrayList<EventRect> eventRects = new ArrayList<EventRect>();
             for (EventRect eventRect : tempEvents) {
-                if (isSameDay(eventRect.event.getStartTime(), dayCounter))
-                    eventRects.add(eventRect);
+                if (isSameDay(eventRect.event.getStartTime(), dayCounter)){
+                    if (!eventRects.contains(eventRect)){
+                        eventRects.add(eventRect);
+                    }
+                }
             }
 
             computePositionOfEvents(eventRects);

--- a/library/src/main/java/com/alamkanak/weekview/WeekViewEvent.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekViewEvent.java
@@ -106,4 +106,21 @@ public class WeekViewEvent {
     public void setId(long id) {
         this.mId = id;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        WeekViewEvent that = (WeekViewEvent) o;
+
+        if (mId != that.mId) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) (mId ^ (mId >>> 32));
+    }
 }


### PR DESCRIPTION
I found a bug in the library. Steps to reproduce:

Add this `MonthChangeListener` to your View:

```java
MonthChangeListener myListener = new WeekView.MonthChangeListener() {
    @Override
    public List<WeekViewEvent> onMonthChange(int i, int i2) {
        ArrayList<WeekViewEvent> list = new ArrayList<>();
        WeekViewEvent event9 = new WeekViewEvent(4, "Very Small", 2015, 4, 15, 3, 0, 2015, 4, 15, 3, 50);
        event9.setColor(Color.argb(175, r.nextInt(256), r.nextInt(256), r.nextInt(256)));
        WeekViewEvent event8 = new WeekViewEvent(5, "Really bottom", 2015, 4, 15, 3, 34, 2015, 4, 15, 3, 50);
        event8.setColor(Color.argb(175, r.nextInt(256), r.nextInt(256), r.nextInt(256)));
        list.add(event8);
        list.add(event9);

        return list;
        }
    });
```
I got that:

![screenshot_2015-04-16-09-18-28](https://cloud.githubusercontent.com/assets/5024077/7176010/cb708e00-e41a-11e4-9d2e-f68ee7da22bd.png)

I searched and I found that the bug is coming from the workflow: you load the day before, the current day and the next day but you add every time the event to the view to be drawn (which adds then every event 3 times).

What I did was, to identify properly every meeting with their Id implementing the `equals` and `hashCode`methods.

It works yet for me. Could someone test that?
        