### PR TITLE
Added the ability to have a min height in minute for an appointment

### DIFF
--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -26,6 +26,7 @@
         <attr name="hourSeparatorHeight" format="dimension"/>
         <attr name="eventTextColor" format="color"/>
         <attr name="eventPadding" format="dimension"/>
+        <attr name="eventMinDurationRepresentation" format="integer"/>
         <attr name="headerColumnBackground" format="color"/>
         <attr name="dayNameLength" format="enum">
             <enum name="length_short" value="1"/>


### PR DESCRIPTION
To avoid to have bad designed appointments because they would have been drawn too small, like this:


![screenshot_2015-04-16-11-10-21](https://cloud.githubusercontent.com/assets/5024077/7177818/14ca17a6-e42a-11e4-98f4-ad141fc442c0.png)

I changed a bit the draw method to have the possibility to include a minimum height (you set in minutes), and it won't change your model class, just the way these appointments are drawn (you can set in your XML file, of course!).

It looks like this, yet (forget about the names, I made a lot of tests :smiley: )


![screenshot_2015-04-16-11-13-20](https://cloud.githubusercontent.com/assets/5024077/7177819/14e8ebd6-e42a-11e4-8012-4c6ca3731971.png)



: 