### PR TITLE
improve scroll/fling performance

### DIFF
--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -43,5 +43,6 @@
         <attr name="overlappingEventGap" format="dimension"/>
         <attr name="eventMarginVertical" format="dimension"/>
         <attr name="xScrollingSpeed" format="float"/>
+        <attr name="eventCornerRadius" format="dimension"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
first try to fix #139

i tried to change it to be more like the examples in android doc

1: https://developer.android.com/training/gestures/scale.html
2: https://developer.android.com/training/gestures/scroll.html

* less calculations in computeScroll()
* scrolling now is done in onScroll() and not in onDraw() anymore
* no more lagging when swiping horizontal and fling is triggered
* only one scroller left

but i have also some questions left, maybe you (@caske33 @lolobosse @alamkanak) can help a little bit:
* there are really a lot of calls of onFirstVisibleDayChanged if there is mScrollListener set while scrolling. i'm not sure how to but shouldn't this be called only after scroll/fling has finished?
* there are calls of canvas.drawRect for "hiding" everything drawn before, how about using clipRect to prevent from drawing in areas that should be empty?