### PR TITLE
Fix display of events with duration that will be smaller in size than the text height of the event

### DIFF
--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -673,6 +673,7 @@ public class WeekView extends View {
      */
     private void drawEvents(Calendar date, float startFromPixel, Canvas canvas) {
         if (mEventRects != null && mEventRects.size() > 0) {
+            Rect rect = new Rect();
             for (int i = 0; i < mEventRects.size(); i++) {
                 if (isSameDay(mEventRects.get(i).event.getStartTime(), date)) {
 
@@ -691,7 +692,9 @@ public class WeekView extends View {
                     if (right < startFromPixel + mWidthPerDay)
                         right -= mOverlappingEventGap;
 
-                    float minTextHeight = mHeaderTextHeight + mHeaderRowPadding;
+                    mEventTextPaint.getTextBounds(mEventRects.get(i).event.getName(), 0, mEventRects.get(i).event.getName().length(), rect);
+
+                    float minTextHeight = rect.height() + mHeaderRowPadding;
                     if (bottom - top < minTextHeight) {
                         bottom = top + minTextHeight;
                     }

--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -96,6 +96,7 @@ public class WeekView extends View {
     private int mHeaderColumnPadding = 10;
     private int mHeaderColumnTextColor = Color.BLACK;
     private int mNumberOfVisibleDays = 3;
+    private int mMinEventDurationMillis = 15*60*1000;
     private int mHeaderRowPadding = 10;
     private int mHeaderRowBackgroundColor = Color.WHITE;
     private int mDayBackgroundColor = Color.rgb(245, 245, 245);
@@ -690,6 +691,11 @@ public class WeekView extends View {
                     if (right < startFromPixel + mWidthPerDay)
                         right -= mOverlappingEventGap;
 
+                    float minTextHeight = mHeaderTextHeight + mHeaderRowPadding * 2;
+                    if (bottom - top < minTextHeight) {
+                        bottom = top + minTextHeight;
+                    }
+
                     // Draw the event and the event name on top of it.
                     RectF eventRectF = new RectF(left, top, right, bottom);
                     if (bottom > mHeaderTextHeight + mHeaderRowPadding * 2 + mHeaderMarginBottom + mTimeTextHeight/2 && left < right &&
@@ -1025,9 +1031,9 @@ public class WeekView extends View {
      */
     private boolean isEventsCollide(WeekViewEvent event1, WeekViewEvent event2) {
         long start1 = event1.getStartTime().getTimeInMillis();
-        long end1 = event1.getEndTime().getTimeInMillis();
+        long end1 = event1.getEndTime().getTimeInMillis() + mMinEventDurationMillis;
         long start2 = event2.getStartTime().getTimeInMillis();
-        long end2 = event2.getEndTime().getTimeInMillis();
+        long end2 = event2.getEndTime().getTimeInMillis() + mMinEventDurationMillis;
         return !((start1 >= end2) || (end1 <= start2));
     }
 
@@ -1268,6 +1274,15 @@ public class WeekView extends View {
 
     public int getDayBackgroundColor() {
         return mDayBackgroundColor;
+    }
+
+    public void setMinEventDurationMillis(int minEventDuration) {
+        mMinEventDurationMillis = minEventDuration;
+        invalidate();
+    }
+
+    public int getMinEventDurationMillis() {
+        return mMinEventDurationMillis;
     }
 
     public void setDayBackgroundColor(int dayBackgroundColor) {

--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -694,7 +694,7 @@ public class WeekView extends View {
 
                     mEventTextPaint.getTextBounds(mEventRects.get(i).event.getName(), 0, mEventRects.get(i).event.getName().length(), rect);
 
-                    float minTextHeight = rect.height() + mHeaderRowPadding;
+                    float minTextHeight = rect.height() + 2*mEventPadding;
                     if (bottom - top < minTextHeight) {
                         bottom = top + minTextHeight;
                     }

--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -691,7 +691,7 @@ public class WeekView extends View {
                     if (right < startFromPixel + mWidthPerDay)
                         right -= mOverlappingEventGap;
 
-                    float minTextHeight = mHeaderTextHeight + mHeaderRowPadding * 2;
+                    float minTextHeight = mHeaderTextHeight + mHeaderRowPadding;
                     if (bottom - top < minTextHeight) {
                         bottom = top + minTextHeight;
                     }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -20,6 +20,7 @@
         <attr name="columnGap" format="dimension"/>
         <attr name="headerColumnTextColor" format="color"/>
         <attr name="noOfVisibleDays" format="integer"/>
+        <attr name="minEventDurationMillis" format="integer"/>
         <attr name="headerRowBackgroundColor" format="color"/>
         <attr name="dayBackgroundColor" format="color"/>
         <attr name="futureBackgroundColor" format="color"/>

--- a/sample/src/main/java/com/alamkanak/weekview/sample/MainActivity.java
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/MainActivity.java
@@ -148,11 +148,11 @@ public class MainActivity extends ActionBarActivity implements WeekView.MonthCha
         Calendar startTime = Calendar.getInstance();
         startTime.set(Calendar.HOUR_OF_DAY, 3);
         startTime.set(Calendar.MINUTE, 0);
-        startTime.set(Calendar.MONTH, newMonth-1);
+        startTime.set(Calendar.MONTH, newMonth - 1);
         startTime.set(Calendar.YEAR, newYear);
         Calendar endTime = (Calendar) startTime.clone();
         endTime.add(Calendar.HOUR, 1);
-        endTime.set(Calendar.MONTH, newMonth-1);
+        endTime.set(Calendar.MONTH, newMonth - 1);
         WeekViewEvent event = new WeekViewEvent(1, getEventTitle(startTime), startTime, endTime);
         event.setColor(getResources().getColor(R.color.event_color_01));
         events.add(event);
@@ -167,6 +167,24 @@ public class MainActivity extends ActionBarActivity implements WeekView.MonthCha
         endTime.set(Calendar.MINUTE, 30);
         endTime.set(Calendar.MONTH, newMonth-1);
         event = new WeekViewEvent(10, getEventTitle(startTime), startTime, endTime);
+        event.setColor(getResources().getColor(R.color.event_color_02));
+        events.add(event);
+
+        startTime = Calendar.getInstance();
+        startTime.set(Calendar.MONTH, newMonth-1);
+        startTime.set(Calendar.MINUTE, 30);
+        endTime = (Calendar) startTime.clone();
+        endTime.set(Calendar.MINUTE, 35);
+        event = new WeekViewEvent(1001, getEventTitle(startTime), startTime, endTime);
+        event.setColor(getResources().getColor(R.color.event_color_02));
+        events.add(event);
+
+        startTime = Calendar.getInstance();
+        startTime.set(Calendar.MONTH, newMonth-1);
+        startTime.set(Calendar.MINUTE, 36);
+        endTime = (Calendar) startTime.clone();
+        endTime.set(Calendar.MINUTE, 40);
+        event = new WeekViewEvent(1002, getEventTitle(startTime), startTime, endTime);
         event.setColor(getResources().getColor(R.color.event_color_02));
         events.add(event);
 


### PR DESCRIPTION
This patch fixes the display of events whose duration is smaller than the text height. When this happens, the rectangle of the display was not being show, only the test. 
Furthermore, a new property has been added to specify the minimum duration that an event should have, when checking for overlapping events. This fixes the issue that when two events with a very small duration where added, close to each other, clicking the older one, hides the newer one.
