### PR TITLE
Reduce much memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,10 +228,15 @@ Changelog
 
 * Added support for overlapping events
 
+**Lai Kitman Fork**
+
+* remove almost all calendar instance to avoid memory leak
+* optimize performance on large amount of events 
+
 License
 ----------
 
-    Copyright 2014 Raquib-ul-Alam
+    Copyright 2017 Lai Kitman
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 19 19:16:06 BDT 2014
+#Fri Mar 03 14:28:32 CST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,17 +5,17 @@ repositories {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 23
+        targetSdkVersion 25
     }
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:appcompat-v7:25.2.0'
 }
 
 apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/library/src/main/java/com/alamkanak/weekview/WeekViewUtil.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekViewUtil.java
@@ -24,16 +24,26 @@ public class WeekViewUtil {
         return dayOne.get(Calendar.YEAR) == dayTwo.get(Calendar.YEAR) && dayOne.get(Calendar.DAY_OF_YEAR) == dayTwo.get(Calendar.DAY_OF_YEAR);
     }
 
+    private static Calendar sDayOne = Calendar.getInstance();
+    private static Calendar sDayTwo = Calendar.getInstance();
+    public static boolean isSameDay(long dayOne, long dayTwo) {
+        sDayOne.setTimeInMillis(dayOne);
+        sDayTwo.setTimeInMillis(dayTwo);
+        return isSameDay(sDayOne, sDayTwo);
+    }
+
+
+    private static final Calendar sToday = Calendar.getInstance();
     /**
      * Returns a calendar instance at the start of this day
      * @return the calendar instance
      */
     public static Calendar today(){
-        Calendar today = Calendar.getInstance();
-        today.set(Calendar.HOUR_OF_DAY, 0);
-        today.set(Calendar.MINUTE, 0);
-        today.set(Calendar.SECOND, 0);
-        today.set(Calendar.MILLISECOND, 0);
-        return today;
+        sToday.setTimeInMillis(System.currentTimeMillis());
+        sToday.set(Calendar.HOUR_OF_DAY, 0);
+        sToday.set(Calendar.MINUTE, 0);
+        sToday.set(Calendar.SECOND, 0);
+        sToday.set(Calendar.MILLISECOND, 0);
+        return sToday;
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.alamkanak.weekview"
         minSdkVersion 9
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -22,6 +22,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:appcompat-v7:25.2.0'
     compile 'com.squareup.retrofit:retrofit:1.9.0'
 }

--- a/sample/src/main/java/com/alamkanak/weekview/sample/AsynchronousActivity.java
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/AsynchronousActivity.java
@@ -49,6 +49,9 @@ public class AsynchronousActivity extends BaseActivity implements Callback<List<
         return matchedEvents;
     }
 
+
+    private static final Calendar sStartTime = Calendar.getInstance();
+    private static final Calendar sEndTime = Calendar.getInstance();
     /**
      * Checks if an event falls into a specific year and month.
      * @param event The event to check for.
@@ -57,7 +60,10 @@ public class AsynchronousActivity extends BaseActivity implements Callback<List<
      * @return True if the event matches the year and month.
      */
     private boolean eventMatches(WeekViewEvent event, int year, int month) {
-        return (event.getStartTime().get(Calendar.YEAR) == year && event.getStartTime().get(Calendar.MONTH) == month - 1) || (event.getEndTime().get(Calendar.YEAR) == year && event.getEndTime().get(Calendar.MONTH) == month - 1);
+        sStartTime.setTimeInMillis(event.getStartTime());
+        sEndTime.setTimeInMillis(event.getEndTime());
+        return (sStartTime.get(Calendar.YEAR) == year && sStartTime.get(Calendar.MONTH) ==  month - 1)
+            || (sEndTime.get(Calendar.YEAR) == year && sEndTime.get(Calendar.MONTH) == month - 1);
     }
 
     @Override


### PR DESCRIPTION
Android-Week-View is a great library that I really love. 
However, I come across a few problem when using this library:

* too much `Calendar.getInstance()` during `onDraw()` method
* too much `new StaticLayout()` during `onDraw()` method
* too much `new float[]` during `onDraw()` method

these codes are not recommended by Android View development document because `onDraw` is called VERY frequently , so even if allocation of a very small size will be drastically amplified, which leads to frequent GC and GC will stop the drawing process and make the view laggy. 

here is my PR: 
 1. replace nearly all `Calendar.getInstance()` by using some `private static final Calendar`, so no more extra allocation during `onDraw()`
2. add these fields to record the drawing status, if the height of `EventRec` is not changed,  the old StaticLayout will be retained and used.
```
private int mAvailableHeight;
private int mAvailableWidth;
private StaticLayout mTextLayout;
private SpannableStringBuilder mStringBuilder
```

I have try my best to not to modify the API, It just take 4 lines change in the demo. 