### PR TITLE
Localize Date Format

### DIFF
--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -21,6 +21,7 @@ import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.text.TextUtils;
 import android.text.format.DateFormat;
+import android.text.format.DateUtils;
 import android.text.style.StyleSpan;
 import android.util.AttributeSet;
 import android.util.TypedValue;
@@ -1302,8 +1303,10 @@ public class WeekView extends View {
                 @Override
                 public String interpretDate(Calendar date) {
                     try {
-                        SimpleDateFormat sdf = mDayNameLength == LENGTH_SHORT ? new SimpleDateFormat("EEEEE M/dd", Locale.getDefault()) : new SimpleDateFormat("EEE M/dd", Locale.getDefault());
-                        return sdf.format(date.getTime()).toUpperCase();
+                        int flags = DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_NO_YEAR | DateUtils.FORMAT_NUMERIC_DATE;
+                        String localizedDate = DateUtils.formatDateTime(getContext(), date.getTime(), flags);
+                        SimpleDateFormat sdf = mDayNameLength == LENGTH_SHORT ? new SimpleDateFormat("EEEEE", Locale.getDefault()) : new SimpleDateFormat("EEE", Locale.getDefault());
+                        return String.format("%s %s", sdf.format(date.getTime()).toUpperCase(), localizedDate);
                     } catch (Exception e) {
                         e.printStackTrace();
                         return "";

--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -1304,7 +1304,7 @@ public class WeekView extends View {
                 public String interpretDate(Calendar date) {
                     try {
                         int flags = DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_NO_YEAR | DateUtils.FORMAT_NUMERIC_DATE;
-                        String localizedDate = DateUtils.formatDateTime(getContext(), date.getTime(), flags);
+                        String localizedDate = DateUtils.formatDateTime(getContext(), date.getTime().getTime(), flags);
                         SimpleDateFormat sdf = mDayNameLength == LENGTH_SHORT ? new SimpleDateFormat("EEEEE", Locale.getDefault()) : new SimpleDateFormat("EEE", Locale.getDefault());
                         return String.format("%s %s", sdf.format(date.getTime()).toUpperCase(), localizedDate);
                     } catch (Exception e) {


### PR DESCRIPTION
Some locales format dates as `dd/MM` rather than `M/dd`.

This PR localizes the date format. 